### PR TITLE
Adding wrappers to more ops.

### DIFF
--- a/library/TensorFlow/DepTyped.hs
+++ b/library/TensorFlow/DepTyped.hs
@@ -17,12 +17,13 @@ module TensorFlow.DepTyped (
   KnownNatList(natListVal),
   constant, placeholder, add, mul, matMul, argMax, softmax, scalar, oneHot,
   oneHot_, reduceMean, softmaxCrossEntropyWithLogits, equal, truncatedNormal,
-  relu, sub, cast, square,
+  relu, sub, cast, square, reshape, shape, sigmoid,
   run, runWithFeeds,
   Tensor, Placeholder, Feed(Feed), FeedList(NilFeedList,(:~~)), render, feed,
   TensorData(TensorData, unTensorData), encodeTensorData,
   Variable(Variable, unVariable), initializedVariable, zeroInitializedVariable, readValue,
   minimizeWith,
+  sigmoidCrossEntropyWithLogits,
 
   Build, Value, Ref, MonadBuild,
   Session, runSession
@@ -30,13 +31,14 @@ module TensorFlow.DepTyped (
 
 import TensorFlow.DepTyped.Ops (constant, placeholder, add, mul, matMul, argMax, softmax, scalar, oneHot,
                                 oneHot_, reduceMean, softmaxCrossEntropyWithLogits, equal, truncatedNormal,
-                                relu, sub, cast, square)
+                                relu, sub, cast, square, reshape, shape, sigmoid)
 import TensorFlow.DepTyped.Session (run, runWithFeeds)
 import TensorFlow.DepTyped.Tensor (Tensor, Placeholder, Feed(Feed), FeedList(NilFeedList,(:~~)), render, feed)
 import TensorFlow.DepTyped.Types (TensorData(TensorData, unTensorData), encodeTensorData)
 import TensorFlow.DepTyped.Base (KnownNatList(natListVal))
 import TensorFlow.DepTyped.Variable (Variable(Variable, unVariable), initializedVariable, zeroInitializedVariable, readValue)
 import TensorFlow.DepTyped.Minimize (minimizeWith)
+import TensorFlow.DepTyped.NN (sigmoidCrossEntropyWithLogits)
 
 import TensorFlow.Core (Build, Value, Ref, MonadBuild)
 import TensorFlow.Session (Session, runSession)

--- a/library/TensorFlow/DepTyped/Base.hs
+++ b/library/TensorFlow/DepTyped/Base.hs
@@ -24,6 +24,7 @@
 module TensorFlow.DepTyped.Base (
   KnownNatList(natListVal),
   ShapeProduct,
+  KnownNatListLength,
   AddPlaceholder,
   UnionPlaceholder,
   PlaceholderNotInList,
@@ -33,7 +34,8 @@ module TensorFlow.DepTyped.Base (
   AddAxisToEndShape
 ) where
 
-import           GHC.TypeLits (Nat, KnownNat, natVal, type (*), Symbol, TypeError, ErrorMessage(Text, ShowType, (:<>:)), type (-))
+import           GHC.TypeLits (Nat, KnownNat, natVal, type (*), Symbol, TypeError, ErrorMessage(Text, ShowType,
+                               (:<>:)), type (-), type (+))
 import           Data.Proxy (Proxy(Proxy))
 import           Data.Promotion.Prelude (type If, type (:<), type (:>), type (:||), type (:==), type Reverse, type Length)
 import           Data.Kind (Constraint, Type)
@@ -46,6 +48,10 @@ instance KnownNatList '[] where
 -- Inductive step
 instance (KnownNat n, KnownNatList ns) => KnownNatList (n ': ns) where
   natListVal _ = natVal (Proxy :: Proxy n) : natListVal (Proxy :: Proxy ns)
+
+type family KnownNatListLength (s :: [Nat]) :: Nat where
+  KnownNatListLength '[] = 0
+  KnownNatListLength (_ ': s) = 1 + KnownNatListLength s
 
 type family ShapeProduct (s :: [Nat]) :: Nat where
   ShapeProduct '[] = 1

--- a/library/TensorFlow/DepTyped/NN.hs
+++ b/library/TensorFlow/DepTyped/NN.hs
@@ -1,0 +1,51 @@
+-- Copyright 2017 Elkin Cruz.
+-- Copyright 2017 James Bowen.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+
+module TensorFlow.DepTyped.NN (
+  sigmoidCrossEntropyWithLogits
+) where
+
+import           GHC.TypeLits (Nat, Symbol)
+import           Data.Kind (Type)
+
+import qualified TensorFlow.Types as TF (TensorType, type OneOf)
+import qualified TensorFlow.NN as TF (sigmoidCrossEntropyWithLogits)
+--import qualified TensorFlow.Tensor as TF (Tensor)
+import           TensorFlow.Tensor (Value)
+import           TensorFlow.Build (MonadBuild)
+
+import           TensorFlow.DepTyped.Base (UnionPlaceholder)
+import           TensorFlow.DepTyped.Tensor (Tensor(Tensor))
+
+
+
+sigmoidCrossEntropyWithLogits :: forall (phs1::[(Symbol,[Nat],Type)]) (phs2::[(Symbol,[Nat],Type)]) a s m.
+           (MonadBuild m, TF.OneOf '[Float, Double] a, TF.TensorType a, Num a)
+           => Tensor s phs1 Value a
+           -> Tensor s phs2 Value a
+           -> m (Tensor s (UnionPlaceholder phs1 phs2) Value a)
+sigmoidCrossEntropyWithLogits (Tensor t1) (Tensor t2) = do
+    t <- TF.sigmoidCrossEntropyWithLogits t1 t2
+    return (Tensor t)

--- a/library/TensorFlow/DepTyped/Ops.hs
+++ b/library/TensorFlow/DepTyped/Ops.hs
@@ -40,7 +40,10 @@ module TensorFlow.DepTyped.Ops (
   relu,
   sub,
   cast,
-  square
+  square,
+  reshape,
+  sigmoid,
+  shape
 ) where
 
 import           GHC.TypeLits (Nat, Symbol, KnownNat, natVal)
@@ -56,15 +59,16 @@ import           Data.ByteString (ByteString)
 import qualified TensorFlow.Ops as TF (constant, add, matMul, placeholder, argMax, scalar,
                                        softmax, oneHot, reduceMean, softmaxCrossEntropyWithLogits,
                                        equal, truncatedNormal, vector, mul, relu, sub, cast, abs, sign,
-                                       neg)
-import qualified TensorFlow.GenOps.Core as TF (square)
+                                       neg, reshape, shape)
+import qualified TensorFlow.GenOps.Core as TF (square, sigmoid)
 import qualified TensorFlow.Types as TF (TensorType, Shape(Shape), type OneOf)
 --import qualified TensorFlow.Tensor as TF (Tensor)
 import           TensorFlow.Tensor (Value)
 import           TensorFlow.Build (Build, MonadBuild)
 
 import           TensorFlow.DepTyped.Base (KnownNatList(natListVal), ShapeProduct, UnionPlaceholder,
-                                           BroadcastShapes, RemoveAxisFromShape, AddAxisToEndShape)
+                                           BroadcastShapes, RemoveAxisFromShape, AddAxisToEndShape,
+                                           KnownNatListLength)
 import           TensorFlow.DepTyped.Tensor (Tensor(Tensor), Placeholder)
 
 
@@ -86,14 +90,14 @@ constant :: forall (s :: [Nat]) (n :: Nat) a.
             (TF.TensorType a, ShapeProduct s ~ n, KnownNatList s)
          => Vector n a
          -> Tensor s '[] Build a
-constant v = Tensor $ TF.constant shape (toList v)
-  where shape = TF.Shape . fmap fromInteger $ natListVal (Proxy :: Proxy s)
+constant v = Tensor $ TF.constant shape' (toList v)
+  where shape' = TF.Shape . fmap fromInteger $ natListVal (Proxy :: Proxy s)
 
 placeholder :: forall (name :: Symbol) (shape :: [Nat]) a m.
                (TF.TensorType a, KnownNatList shape, MonadBuild m)
             => m (Placeholder name shape a)
-placeholder = Tensor <$> TF.placeholder shape
-  where shape = TF.Shape . fmap fromInteger $ natListVal (Proxy :: Proxy shape)
+placeholder = Tensor <$> TF.placeholder shape'
+  where shape' = TF.Shape . fmap fromInteger $ natListVal (Proxy :: Proxy shape)
 
 add :: forall (shape1 :: [Nat]) (shape2 :: [Nat]) (phs1 :: [(Symbol, [Nat], Type)]) (phs2 :: [(Symbol, [Nat], Type)]) v1 v2 a.
        TF.OneOf '[(Complex Double), (Complex Float), ByteString, Int16, Int32, Int64, Int8, Word16, Word8, Double, Float] a
@@ -194,3 +198,22 @@ cast (Tensor t) = Tensor $ TF.cast t
 square :: TF.OneOf '[(Complex Double), (Complex Float), Int32, Int64, Word16, Double, Float] a
     => Tensor shape phs v a -> Tensor shape phs Build a
 square (Tensor t) = Tensor (TF.square t)
+
+reshape :: forall t shape1 shape2 phs v.
+           (TF.TensorType t, ShapeProduct shape1 ~ ShapeProduct shape2, KnownNatList shape2)
+        => Tensor shape1 phs v t
+        -> Tensor shape2 phs Build t
+reshape (Tensor t) = Tensor $ TF.reshape t $ TF.vector $ map
+            (fromInteger :: Integer -> Int32)
+            (natListVal (Proxy :: Proxy shape2))
+
+sigmoid :: forall (phs::[(Symbol,[Nat],Type)]) a v s.
+           TF.OneOf '[Complex Double, Complex Float, Word16, Double, Float] a
+        =>   Tensor s phs v a -> Tensor s phs Build a
+sigmoid (Tensor t) = Tensor (TF.sigmoid t)
+
+shape :: forall t shape phs v.
+         (TF.TensorType t, KnownNatList shape) -- , TF.OneOf '[Int32, Int64] out_type
+       => Tensor shape phs v t
+       -> Tensor '[KnownNatListLength shape] phs Build Int32
+shape (Tensor t) = Tensor (TF.shape t)

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
   - 'tensorflow-mnist-deptyped'
   - location:
       git: https://github.com/tensorflow/haskell.git
-      commit: a8405d15a22fc62dce8e868623e12a83e11f56b8
+      commit: 8e1d85b5e5bd56d54ff6d463c8581c57ab5526d9
     subdirs:
       - tensorflow
       - tensorflow-core-ops
@@ -20,7 +20,7 @@ packages:
       - tensorflow-test
     extra-dep: true
 extra-deps:
-  - proto-lens-protobuf-types-0.2.1.0
+  - proto-lens-protobuf-types-0.2.2.0
   - proto-lens-0.2.2.0
   - proto-lens-protoc-0.2.2.3
   - proto-lens-descriptors-0.2.2.0

--- a/tensorflow-deptyped.cabal
+++ b/tensorflow-deptyped.cabal
@@ -41,6 +41,7 @@ library
     , TensorFlow.DepTyped.Tensor
     , TensorFlow.DepTyped.Types
     , TensorFlow.DepTyped.Session
+    , TensorFlow.DepTyped.NN
     , TensorFlow.DepTyped.Ops
     , TensorFlow.DepTyped.Output
     , TensorFlow.DepTyped.Variable


### PR DESCRIPTION
Wrappers for `reshape`, `shape`, `sigmoid` and `sigmoidCrossEntropyWithLogits`.